### PR TITLE
React Native 0.60+ linking with cocoapods

### DIFF
--- a/ios/ReactNativeIOSLibrary.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeIOSLibrary.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		4565653F26E0BDE7007DA850 /* AM5Module.m in Sources */ = {isa = PBXBuildFile; fileRef = 4565653D26E0BDE6007DA850 /* AM5Module.m */; };
 		4565654026E0BDE7007DA850 /* AM5ProfileModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 4565653E26E0BDE7007DA850 /* AM5ProfileModule.m */; };
 		45A72D18256E5FCB00825201 /* BP7Module.m in Sources */ = {isa = PBXBuildFile; fileRef = 45A72D16256E5FCB00825201 /* BP7Module.m */; };
-		45A870EA2AAF11CC00C2A284 /* iHealthSDK2.10.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 45A870E92AAF11CC00C2A284 /* iHealthSDK2.10.0.a */; };
+		45A870EA2AAF11CC00C2A284 /* libiHealthSDK2.10.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 45A870E92AAF11CC00C2A284 /* libiHealthSDK2.10.0.a */; };
 		8CCCE9B21E5ADF49007F7FE4 /* PO3Module.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CCCE9AF1E5ADF49007F7FE4 /* PO3Module.m */; };
 		8CCCE9B31E5ADF49007F7FE4 /* POProfileModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CCCE9B11E5ADF49007F7FE4 /* POProfileModule.m */; };
 		8CCCE9E31E5E7C58007F7FE4 /* HS6ProfileModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CCCE9E21E5E7C58007F7FE4 /* HS6ProfileModule.m */; };
@@ -258,7 +258,7 @@
 		45A870E62AAF11CB00C2A284 /* AM6Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AM6Constants.h; sourceTree = "<group>"; };
 		45A870E72AAF11CB00C2A284 /* SDKInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDKInfo.h; sourceTree = "<group>"; };
 		45A870E82AAF11CB00C2A284 /* BPLoopMeasureSettingModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPLoopMeasureSettingModel.h; sourceTree = "<group>"; };
-		45A870E92AAF11CC00C2A284 /* iHealthSDK2.10.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = iHealthSDK2.10.0.a; sourceTree = "<group>"; };
+		45A870E92AAF11CC00C2A284 /* libiHealthSDK2.10.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libiHealthSDK2.10.0.a; sourceTree = "<group>"; };
 		8CCCE9AE1E5ADF49007F7FE4 /* PO3Module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PO3Module.h; sourceTree = "<group>"; };
 		8CCCE9AF1E5ADF49007F7FE4 /* PO3Module.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PO3Module.m; sourceTree = "<group>"; };
 		8CCCE9B01E5ADF49007F7FE4 /* POProfileModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = POProfileModule.h; sourceTree = "<group>"; };
@@ -317,7 +317,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				45A870EA2AAF11CC00C2A284 /* iHealthSDK2.10.0.a in Frameworks */,
+				45A870EA2AAF11CC00C2A284 /* libiHealthSDK2.10.0.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -439,7 +439,7 @@
 			isa = PBXGroup;
 			children = (
 				45A8704D2AAF11CA00C2A284 /* Headers */,
-				45A870E92AAF11CC00C2A284 /* iHealthSDK2.10.0.a */,
+				45A870E92AAF11CC00C2A284 /* libiHealthSDK2.10.0.a */,
 			);
 			path = Communication_SDK;
 			sourceTree = "<group>";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ihealth/ihealthlibrary-react-native",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "React Native Model for iHealth Library",
     "main": "index.js",
     "scripts": {
@@ -17,4 +17,4 @@
     },
     "homepage": "https://github.com/iHealthDeviceLabs/iHealthLibrary_ReactNative#readme"
   }
-  
+

--- a/rn-ihealth.podspec
+++ b/rn-ihealth.podspec
@@ -1,0 +1,21 @@
+require "json"
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = "rn-ihealth"
+  s.version      = package["version"]
+  s.summary      = package["description"]
+  s.homepage     = package['homepage']
+  s.license      = package['license']
+  s.authors      = package['author']
+
+  s.platform     = :ios, "9.0"
+  s.ios.deployment_target = '9.0'
+  s.source       = { :git => "https://github.com/iHealthLab/iHealth-rn-sdk.git", :tag => "v#{s.version}" }
+  s.source_files = "ios/**/*.{h,m}"
+  s.public_header_files = "ios/ReactNativeIOSLibrary/Communication_SDK/Headers/*.h"
+  s.vendored_libraries  = "ios/ReactNativeIOSLibrary/Communication_SDK/libiHealthSDK2.10.0.a"
+  s.requires_arc = true
+
+  s.dependency 'React-Core'
+end


### PR DESCRIPTION
The React Native integration did not work on project above 0.60 because of the new automatic linking system (with cocoapods).
This PR adds the Podspec for the library so it works on iOS, Android did work.