### PR TITLE
Rename iHealthSDK iOS lib and bump podspec to 2.14.0

### DIFF
--- a/ReactNativeIOSLibrary.podspec
+++ b/ReactNativeIOSLibrary.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/iHealthLab/iHealth-rn-sdk.git", :tag => "v#{s.version}" }
   s.source_files = "ios/**/*.{h,m}"
   s.public_header_files = "ios/ReactNativeIOSLibrary/Communication_SDK/Headers/*.h"
-  s.vendored_libraries  = "ios/ReactNativeIOSLibrary/Communication_SDK/libiHealthSDK2.13.0.a"
+  s.vendored_libraries  = "ios/ReactNativeIOSLibrary/Communication_SDK/libiHealthSDK2.14.0.a"
   s.requires_arc = true
 
   s.dependency 'React-Core'


### PR DESCRIPTION
### Summary

This updates the iHealth iOS SDK integration so that the static library matches what is defined in the ReactNativeIOSLibrary.podspec.
- Renames iHealthSDK2.14.0.a to libiHealthSDK2.14.0.a
- Updates the podspec to reference version 2.14.0 instead of 2.13.0

### Motivation

Previously, the podspec expected a different library name/version than the actual .a file in the repo. As a result, the iHealth SDK static library was not automatically included in the build via CocoaPods and had to be added manually in Xcode. This change aligns the podspec and library file so the SDK is correctly linked as part of the normal CocoaPods integration, with no manual Xcode configuration required.